### PR TITLE
Bugfix counter init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ dll/
 tmp/
 
 *.json
+COUNTER.bin

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.idemia.tec.jkt</groupId>
 	<artifactId>cardiotest</artifactId>
-	<version>2020.09.02-SNAPSHOT</version>
+	<version>2020.09.03-SNAPSHOT</version>
 	<name>cardiotest</name>
 	<description>TEC test suite</description>
 

--- a/src/main/java/com/idemia/tec/jkt/cardiotest/service/RunServiceImpl.java
+++ b/src/main/java/com/idemia/tec/jkt/cardiotest/service/RunServiceImpl.java
@@ -160,6 +160,11 @@ public class RunServiceImpl implements RunService {
                 }
             }
             catch (IOException e) { e.printStackTrace(); }
+            // initiate zero counter
+            File srcCntr = new File("COUNTER.bin");
+            File tarCntr = new File(scriptsDirectory + "COUNTER.bin");
+            try { Files.copy(srcCntr.toPath(), tarCntr.toPath(), StandardCopyOption.REPLACE_EXISTING); }
+            catch (IOException e) { e.printStackTrace(); }
         }
         // copy variable file to project directory
         File sourceVarFile = new File(root.getRunSettings().getAdvSaveVariablesPath());


### PR DESCRIPTION
Each RFM script initiates counter to zero which leads to low counter. Bug fix implemented by copying zero COUNTER.bin to scripts directory if it does not exist at beginning.